### PR TITLE
Unity 2022 LTS Support

### DIFF
--- a/Runtime/RenderPipeline/PSXRenderPipelineAsset.cs
+++ b/Runtime/RenderPipeline/PSXRenderPipelineAsset.cs
@@ -1,13 +1,16 @@
 using System;
-using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Rendering;
-using UnityEngine.Serialization;
 
 namespace HauntedPSX.RenderPipelines.PSX.Runtime
 {
     public partial class PSXRenderPipelineAsset : RenderPipelineAsset
     {
+        #if UNITY_2022_3_OR_NEWER
+        // Shader stripping changed in Core RP 14.0.8 which used by Unity 2022 LTS and later
+        public override string renderPipelineShaderTag => PSXStringConstants.s_GlobalRenderPipelineStr;
+        #endif
+
         PSXRenderPipelineAsset()
         {
         }
@@ -81,10 +84,10 @@ namespace HauntedPSX.RenderPipelines.PSX.Runtime
 
         [SerializeField]
         public PSXRenderPipelineResources renderPipelineResources;
-        
+
         // TODO: Currently the SRP Batcher is forced off due to a D3D11 swap chain crash in HPSXRP.
         // Expose this option to users once the SRP Batcher stabilizes / once the engine is fixed.
-        // 
+        //
         // [SerializeField]
         // public bool isSRPBatcherEnabled = false;
     }


### PR DESCRIPTION
Add renderPipelineShaderTag to render pipeline asset to prevent shader stripping

Shader stripping changed in Core RP 14.0.8 which used by Unity 2022 LTS